### PR TITLE
Add support for non-git directories and improve branch handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:13-slim@sha256:c85a2732e97694ea77237c61304b3bb410e0e961dd6ee945997a06c788c545bb
 
+ARG GOLANG_VERSION=1.25.0
+ARG HADOLINT_VERSION=2.12.0
+
 ENV DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean
 # hadolint ignore=DL3008
@@ -32,7 +35,8 @@ RUN sed -i 's/^UID_MIN.*/UID_MIN 1000/' /etc/login.defs && \
 # Install uv and uvx from the official Astral image
 COPY --from=ghcr.io/astral-sh/uv:latest@sha256:4de5495181a281bc744845b9579acf7b221d6791f99bcc211b9ec13f417c2853 /uv /uvx /bin/
 
-RUN curl -fsSLo /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 && \
+# Install hadolint
+RUN curl -fsSLo /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v${HADOLINT_VERSION}/hadolint-Linux-x86_64 && \
     install /tmp/hadolint /usr/local/bin && \
     rm -f /tmp/hadolint
 
@@ -43,6 +47,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pipenv \
     poetry \
     pre-commit
+
+# Install golang
+RUN curl -fsSLo /tmp/go.tar.gz https://go.dev/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf /tmp/go.tar.gz && \
+    rm -f /tmp/go.tar.gz
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install coding agents
 # hadolint ignore=DL3016

--- a/start-work
+++ b/start-work
@@ -8,12 +8,13 @@ IMAGE_NAME="ghcr.io/johnstrunk/agent-container"
 function usage {
     cat - <<EOF
 $0: Start using a coding agent on a git worktree
-Usage: $0 <branch_name>
+Usage: $0 [<branch_name>]
   <branch_name>: The name of the branch to create or switch to
 
 * Worktrees are stored in $WORKTREE_BASE_DIR.
 * If the branch does not exist, it will be created from the current HEAD.
 * If the branch exists, it will switch to that branch.
+* If not in a git repository or a branch name is not provided, the current directory will be used.
 EOF
 }
 
@@ -41,9 +42,11 @@ function setup_worktree {
     fi
 }
 
-if [[ $# -lt 1 ]]; then
-    usage
-    exit 1
+if [[ $# -eq 1  && -d .git ]]; then
+    USE_GIT=1
+    BRANCH_NAME="$1"
+else
+    USE_GIT=0
 fi
 
 # Ensure the container image is built
@@ -52,27 +55,20 @@ build_image
 # Create the base directory if it doesn't exist
 mkdir -p "$WORKTREE_BASE_DIR"
 
-BRANCH_NAME="$1"
-if [[ -z "$BRANCH_NAME" ]]; then
-    usage
-    exit 1
-fi
-
-if [[ -d .git ]]; then
-    IS_GIT_REPO=1
+if [[ "$USE_GIT" == 1 ]]; then
     REPO_NAME="$(basename "$(git rev-parse --show-toplevel)")"
     WORKTREE_DIR="$WORKTREE_BASE_DIR/${REPO_NAME}-${BRANCH_NAME}"
     CONTANIER_NAME="${REPO_NAME}-${BRANCH_NAME}"
     setup_worktree "$WORKTREE_DIR" "$BRANCH_NAME"
 else
-    echo "NOT a git repository! --- Ignoring branch name and using current directory."
+    echo "Using current directory."
     REPO_NAME="$(basename "$(pwd)")"
     WORKTREE_DIR="$(pwd)"
     CONTANIER_NAME="local-$REPO_NAME"
 fi
 
 # Need to make the main repo directory available in the container
-if [[ -n "$IS_GIT_REPO" ]]; then
+if [[ "$USE_GIT" == 1 ]]; then
     MAIN_REPO_DIR=$(awk '{ print $2 }' "${WORKTREE_DIR}/.git")
     MAIN_REPO_DIR="${MAIN_REPO_DIR%%.git*}"
 else
@@ -118,6 +114,6 @@ if [[ -f "$WORKTREE_DIR/.claude/settings.local.json" ]]; then
 fi
 
 # Remove the worktree after exiting the container
-if [[ -n "$IS_GIT_REPO" ]]; then
+if [[ "$USE_GIT" == 1 ]]; then
     git worktree remove "$WORKTREE_DIR" || echo "Not removing worktree $(basename "$WORKTREE_DIR"), it may still be in use."
 fi


### PR DESCRIPTION
This pull request updates the development container and the `start-work` script to improve flexibility and maintainability. The main changes include parameterizing tool versions in the `Dockerfile`, adding Go installation, and making the `start-work` script work even outside a git repository or without a branch name.

**Dockerfile improvements:**

* Added build arguments `GOLANG_VERSION` and `HADOLINT_VERSION` to make tool versions configurable.
* Refactored the `hadolint` installation to use the `HADOLINT_VERSION` build argument.
* Added installation steps for Go using the `GOLANG_VERSION` argument and updated the `PATH`.

**start-work script enhancements:**

* Updated usage instructions and logic to allow running the script without a branch name or outside a git repository; in such cases, the current directory is used. [[1]](diffhunk://#diff-d39e43e2f817609b90a5f97a34da21f7881654bea355b5e892a71629ff3f17c8L11-R17) [[2]](diffhunk://#diff-d39e43e2f817609b90a5f97a34da21f7881654bea355b5e892a71629ff3f17c8L44-R49)
* Refactored branch and git repository detection logic to use a `USE_GIT` flag for better clarity and maintainability. [[1]](diffhunk://#diff-d39e43e2f817609b90a5f97a34da21f7881654bea355b5e892a71629ff3f17c8L55-R71) [[2]](diffhunk://#diff-d39e43e2f817609b90a5f97a34da21f7881654bea355b5e892a71629ff3f17c8L121-R117)