### PR TITLE
Add support for executing commands in the agent container

### DIFF
--- a/start-work
+++ b/start-work
@@ -8,13 +8,15 @@ IMAGE_NAME="ghcr.io/johnstrunk/agent-container"
 function usage {
     cat - <<EOF
 $0: Start using a coding agent on a git worktree
-Usage: $0 [<branch_name>]
-  <branch_name>: The name of the branch to create or switch to
+Usage: $0 [-b <branch_name>] [command...]
+  -b <branch_name>: The name of the branch to create or switch to
+  command...: Optional command to execute in the container (container will exit after execution)
 
 * Worktrees are stored in $WORKTREE_BASE_DIR.
 * If the branch does not exist, it will be created from the current HEAD.
 * If the branch exists, it will switch to that branch.
 * If not in a git repository or a branch name is not provided, the current directory will be used.
+* If a command is provided, it will be executed in the container and the container will exit.
 EOF
 }
 
@@ -42,11 +44,32 @@ function setup_worktree {
     fi
 }
 
-if [[ $# -eq 1  && -d .git ]]; then
+# Parse command line options
+BRANCH_NAME=""
+CONTAINER_COMMAND=()
+USE_GIT=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -b|--branch)
+            BRANCH_NAME="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            # All remaining arguments are the command to execute
+            CONTAINER_COMMAND=("$@")
+            break
+            ;;
+    esac
+done
+
+# Determine if we should use git worktrees
+if [[ -n "$BRANCH_NAME" && -d .git ]]; then
     USE_GIT=1
-    BRANCH_NAME="$1"
-else
-    USE_GIT=0
 fi
 
 # Ensure the container image is built
@@ -76,7 +99,11 @@ else
 fi
 
 # Start the agent container, mounting the worktree
-echo "Starting agent container on $WORKTREE_DIR..."
+if [[ ${#CONTAINER_COMMAND[@]} -gt 0 ]]; then
+    echo "Starting agent container on $WORKTREE_DIR and executing: ${CONTAINER_COMMAND[*]}"
+else
+    echo "Starting agent container on $WORKTREE_DIR..."
+fi
 
 
 # - Give access to the Docker socket to allow starting MCP servers from within the container
@@ -105,7 +132,7 @@ docker run --rm -it \
     -v "$HOME/.claude.json:/.claude.json" \
     -v "$HOME/.config/gcloud:/.gcloud" \
     \
-    ghcr.io/johnstrunk/agent-container:latest
+    ghcr.io/johnstrunk/agent-container:latest "${CONTAINER_COMMAND[@]}"
 
 # If .cloude/settings.local.json exists in the worktree, display its contents
 if [[ -f "$WORKTREE_DIR/.claude/settings.local.json" ]]; then


### PR DESCRIPTION
Introduced a new option `-b <branch_name>` to specify the branch name.
Updated the usage message to reflect the new option and added support for
executing commands in the container. The script now parses command-line
options to determine the branch name and any commands to execute. If a
command is provided, it will be executed in the container, and the
container will exit afterward. Updated the Docker run command to pass any
provided commands to the container.

Signed-off-by: John Strunk <jstrunk@redhat.com>
