### PR TITLE
Add dvc to python tools in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:13-slim@sha256:c2880112cc5c61e1200c26f106e4123627b49726375eb5846313d
 
 ARG GOLANG_VERSION=1.25.0
 ARG HADOLINT_VERSION=2.12.0
-ENV PYTHON_TOOLS=pipenv,poetry,pre-commit
+ENV PYTHON_TOOLS=dvc[all],pipenv,poetry,pre-commit
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean

--- a/entrypoint_user.sh
+++ b/entrypoint_user.sh
@@ -4,9 +4,12 @@ set -e -o pipefail
 # Install python tools now that we have the right user
 # shellcheck disable=SC2016
 echo 'export PATH="/home/user/.local/bin:$PATH"' >> ~/.bashrc
+echo -n "Installing Python tools:"
 for tool in $(echo "$PYTHON_TOOLS" | tr ',' ' '); do
+    echo -n " $tool"
     uv tool install -q "$tool"
 done
+echo " ...done"
 
 pre-commit gc > /dev/null 2>&1 || true
 (pre-commit install-hooks > /dev/null 2>&1 || true) &


### PR DESCRIPTION
Added dvc[all] to the list of Python tools to be installed in the
Dockerfile. Updated the entrypoint script to provide feedback during the
installation process, displaying the tools being installed and indicating
completion.

Signed-off-by: John Strunk <jstrunk@redhat.com>
